### PR TITLE
macOS SSL certificate verification fix + small general improvements

### DIFF
--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 import tkinter
 import webbrowser
 from tkinter import PhotoImage
@@ -21,6 +22,11 @@ ytdwntitle = ("BebasNeue", 25)
 finished = ("IndieFlower", 15)
 btns = ("RobotoMono", 10)
 creditfnt = ("Cantarell", 10)
+
+
+def main():
+    ssl._create_default_https_context = ssl._create_unverified_context
+    app.mainloop()
 
 
 def create_toplevel(title, message):
@@ -181,4 +187,5 @@ dev = customtkinter.CTkButton(master=app, text="YTDownloader by Kavindu Nimsara 
 dev.place(relx=0.5, rely=0.95, anchor=tkinter.CENTER)
 
 # -----------------------------------------------------------------
-app.mainloop()
+if __name__ == "__main__":
+    main()

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -38,19 +38,6 @@ def create_toplevel(title, message):
     window.title(title)
 
 
-def run_app():
-    link = ytlink.get()
-    if not link:
-        create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")
-    else:
-        yt = YouTube(link)
-
-        ys = yt.streams.get_highest_resolution()
-
-        ys.download(output_path=filepath)
-        create_toplevel("YTDOWNLOADER - Successfully Downloaded", "Successfully Downloaded")
-
-
 def confirm():
     link = ytlink.get()
     yt = YouTube(link)
@@ -70,7 +57,20 @@ def confirm():
     length.place(relx=0.05, rely=0.65, anchor="w")
 
 
-def audio():
+def download_mp4():
+    link = ytlink.get()
+    if not link:
+        create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")
+    else:
+        yt = YouTube(link)
+
+        ys = yt.streams.get_highest_resolution()
+
+        ys.download(output_path=filepath)
+        create_toplevel("YTDOWNLOADER - Successfully Downloaded", "Successfully Downloaded")
+
+
+def download_mp3():
     link = ytlink.get()
     if not link:
         create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")
@@ -145,7 +145,7 @@ confirmbtn.place(relx=0.355, rely=0.49, anchor=tkinter.CENTER)
 # -----------------------Download Button-------------------------
 
 downloadbtn = customtkinter.CTkButton(master=app, text="Download",
-                                      command=run_app,
+                                      command=download_mp4,
                                       fg_color="white",
                                       text_color="black",
                                       corner_radius=25,
@@ -155,7 +155,7 @@ downloadbtn.place(relx=0.65, rely=0.42, anchor=tkinter.CENTER)
 # ---------------------Download audio Button-----------------------
 
 audiodown = customtkinter.CTkButton(master=app, text="Download MP3",
-                                    command=audio,
+                                    command=download_mp3,
                                     fg_color="white",
                                     text_color="black",
                                     corner_radius=25,

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -113,7 +113,7 @@ frame = customtkinter.CTkFrame(master=app,
                                corner_radius=10,
                                border_width=7,
                                border_color="black",
-                               fg_color="#757575")
+                               fg_color="#181818")
 frame.place(relx=0.5, rely=0.7, anchor=tkinter.CENTER)
 
 # ----------------------------Title----------------------------

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -53,7 +53,7 @@ def confirm():
     title = customtkinter.CTkLabel(master=frame, text=f"Title : {vidtitle}")
     title.place(relx=0.05, rely=0.35, anchor="w")
 
-    views = customtkinter.CTkLabel(master=frame, text=f"Number of Views : {numviews}")
+    views = customtkinter.CTkLabel(master=frame, text=f"Number of Views : {numviews:,}")
     views.place(relx=0.05, rely=0.5, anchor="w")
 
     length = customtkinter.CTkLabel(master=frame,

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -62,6 +62,7 @@ def confirm():
 
 
 def download_mp4():
+    confirm()
     link = ytlink.get()
     if not link:
         create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")
@@ -75,6 +76,7 @@ def download_mp4():
 
 
 def download_mp3():
+    confirm()
     link = ytlink.get()
     if not link:
         create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -151,7 +151,7 @@ confirmbtn.place(relx=0.355, rely=0.49, anchor=tkinter.CENTER)
 
 # -----------------------Download Button-------------------------
 
-downloadbtn = customtkinter.CTkButton(master=app, text="Download",
+downloadbtn = customtkinter.CTkButton(master=app, text="Download MP4",
                                       command=download_mp4,
                                       fg_color="white",
                                       text_color="black",

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -44,21 +44,24 @@ def create_toplevel(title, message):
 
 def confirm():
     link = ytlink.get()
-    yt = YouTube(link)
+    if not link:
+        create_toplevel("YTDOWNLOADER - Error", "No valid link in input field")
+    else:
+        yt = YouTube(link)
 
-    vidtitle = yt.title
-    numviews = yt.views
-    vidlen = yt.length
+        vidtitle = yt.title
+        numviews = yt.views
+        vidlen = yt.length
 
-    title = customtkinter.CTkLabel(master=frame, text=f"Title : {vidtitle}")
-    title.place(relx=0.05, rely=0.35, anchor="w")
+        title = customtkinter.CTkLabel(master=frame, text=f"Title : {vidtitle}")
+        title.place(relx=0.05, rely=0.35, anchor="w")
 
-    views = customtkinter.CTkLabel(master=frame, text=f"Number of Views : {numviews:,}")
-    views.place(relx=0.05, rely=0.5, anchor="w")
+        views = customtkinter.CTkLabel(master=frame, text=f"Number of Views : {numviews:,}")
+        views.place(relx=0.05, rely=0.5, anchor="w")
 
-    length = customtkinter.CTkLabel(master=frame,
-                                    text=f"Length of Video : {vidlen} secs")
-    length.place(relx=0.05, rely=0.65, anchor="w")
+        length = customtkinter.CTkLabel(master=frame,
+                                        text=f"Length of Video : {vidlen} secs")
+        length.place(relx=0.05, rely=0.65, anchor="w")
 
 
 def download_mp4():

--- a/ytDownloader.py
+++ b/ytDownloader.py
@@ -23,9 +23,13 @@ finished = ("IndieFlower", 15)
 btns = ("RobotoMono", 10)
 creditfnt = ("Cantarell", 10)
 
+# ----Default file path----
+filepath = os.path.join(os.path.expanduser("~"), "Desktop")
+
 
 def main():
     ssl._create_default_https_context = ssl._create_unverified_context
+    directory(True)
     app.mainloop()
 
 
@@ -131,9 +135,12 @@ destinationtext.place(relx=0.1, rely=0.3)
 
 
 # ----------------------Open Directory-----------------------------
-def directory():
+def directory(first_run=False):
     global filepath
-    filepath = filedialog.askdirectory(title="Select A Dir")
+    if first_run:
+        destinationtext.configure(text=filepath, state="disabled")
+    else:
+        filepath = filedialog.askdirectory(title="Select A Dir")
     destinationtext.configure(text=filepath, state="disabled")
 
 


### PR DESCRIPTION
There's an issue on macOS that prevented the app from working if the user didn't have the Python certificates installed (`SSL:CERTIFICATE_VERIFY_FAILED`). I disabled certificate validation which fixes this issue but this is not a recommended fix and should be changed in the future when a better solution is found.

I also made some small general improvements from UI changes (like thousands separator to the view count, download button text) to UX changes (like default save path, error messages,...).

You can see what I changed in my commits below.